### PR TITLE
Added token counting and Makefile

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,5 @@ jobs:
       - name: Get dependencies
         run: |
           go get -v -t -d ./...
-      - name: Build
-        run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v .
       - name: Test
         run: go test ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,11 +20,11 @@ jobs:
         run: |
           go get -v -t -d ./...
       - name: Build Linux
-        run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -o summairpg-linux . 
+        run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -o summairpg-linux cmd/summairpg/main.go
       - name: Build darwin
-        run: CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -v -o summairpg-darwin . 
+        run: CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -v -o summairpg-darwin cmd/summairpg/main.go
       - name: Build windows
-        run: CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -v -o summairpg.exe . 
+        run: CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -v -o summairpg.exe cmd/summairpg/main.go
       - uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .env
-summairpg
+summairpg-linux
+summairpg-darwin
+summairpg.exe
 summairpg-config.json
 transcript.txt

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+
+all: build test
+
+build:
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o summairpg-linux cmd/summairpg/main.go
+	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -o summairpg-darwin cmd/summairpg/main.go
+	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -o summairpg.exe cmd/summairpg/main.go
+
+test:
+	go test ./...

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ With the default settings this will create a `summairpg-config.json` file contai
 These are all of the available parameters:
 
 ```
-$ ./summairpg --help
-Usage of ./summairpg:
+$ ./summairpg-linux --help
+Usage of ./summairpg-linux:
   -audio-dir string
         The directory that contains all of the audio files that should be transcribed (default "input")
   -audio-display-transcript
@@ -68,6 +68,8 @@ Usage of ./summairpg:
         Store the provided command-line arguments in the summairpg-config.json (default true)
   -ollama-address string
         The host:port of the Ollama HTTP API. (default "127.0.0.1:11434")
+  -ollama-context-length-override int
+        override the context length (num_ctx) that would else be determined by the model
   -ollama-enabled
         set to false to disable the Ollama endpoint for summarization (default true)
   -ollama-model string

--- a/cmd/summairpg/main.go
+++ b/cmd/summairpg/main.go
@@ -71,6 +71,9 @@ func evaluateSummary(cfg *config.App, lines []transcribe.Line) {
 	case cfg.Ollama.Enabled:
 		slog.Info("starting summary now", "model", cfg.Ollama.Model, "address", cfg.Ollama.Address)
 		oc := summarize.NewOllamaClient(cfg.Ollama.Address, cfg.Ollama.Model)
+		if cfg.Ollama.ContextLengthOverride > 0 {
+			oc.ContextLength = cfg.Ollama.ContextLengthOverride
+		}
 		if cfg.Ollama.UpdateModel {
 			slog.Info("updating Ollama model", "model", cfg.Ollama.Model)
 			if err := oc.UpdateModel(); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,15 @@ module github.com/MrWong99/summairpg
 
 go 1.22.1
 
-require github.com/itzg/go-flagsfiller v1.14.0
+require (
+	github.com/itzg/go-flagsfiller v1.14.0
+	github.com/pkoukk/tiktoken-go v0.1.6
+	github.com/pkoukk/tiktoken-go-loader v0.0.1
+	github.com/sashabaranov/go-openai v1.23.0
+)
 
 require (
+	github.com/dlclark/regexp2 v1.10.0 // indirect
+	github.com/google/uuid v1.3.0 // indirect
 	github.com/iancoleman/strcase v0.3.0 // indirect
-	github.com/sashabaranov/go-openai v1.23.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,17 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.10.0 h1:+/GIL799phkJqYW+3YbOd8LCcbHzT0Pbo8zl70MHsq0=
+github.com/dlclark/regexp2 v1.10.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/iancoleman/strcase v0.3.0 h1:nTXanmYxhfFAMjZL34Ov6gkzEsSJZ5DbhxWjvSASxEI=
 github.com/iancoleman/strcase v0.3.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/itzg/go-flagsfiller v1.14.0 h1:GQOO5Uiy9eQZaJM5f/DjLf3VAn1PNbEHiK/Igv5Qjcc=
 github.com/itzg/go-flagsfiller v1.14.0/go.mod h1:vSclFjMCgjtH6SB0tCkVyX/OwO/aaInbKmX6H8iJ54Y=
+github.com/pkoukk/tiktoken-go v0.1.6 h1:JF0TlJzhTbrI30wCvFuiw6FzP2+/bR+FIxUdgEAcUsw=
+github.com/pkoukk/tiktoken-go v0.1.6/go.mod h1:9NiV+i9mJKGj1rYOT+njbv+ZwA/zJxYdewGl6qVatpg=
+github.com/pkoukk/tiktoken-go-loader v0.0.1 h1:aOB2gRFzZTCCPi3YsOQXJO771P/5876JAsdebMyazig=
+github.com/pkoukk/tiktoken-go-loader v0.0.1/go.mod h1:4mIkYyZooFlnenDlormIo6cd5wrlUKNr97wp9nGgEKo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sashabaranov/go-openai v1.23.0 h1:KYW97r5yc35PI2MxeLZ3OofecB/6H+yxvSNqiT9u8is=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -58,6 +58,8 @@ type Ollama struct {
 	Address string `json:"address" default:"127.0.0.1:11434" usage:"The host:port of the Ollama HTTP API."`
 	// Model to use. See https://ollama.com/library
 	Model string `json:"model" default:"llama3:70b" usage:"Ollama model to use. See https://ollama.com/library"`
+	// ContextLengthOverride will override the context length (num_ctx) that would else be determined by the model.
+	ContextLengthOverride int `json:"content-length-override" default:"0" usage:"override the context length (num_ctx) that would else be determined by the model"`
 	// UpdateModel if the model should be updated or pulled before use.
 	UpdateModel bool `json:"update-model" default:"true" usage:"set to false to disable pulling the latest version of the model"`
 }
@@ -154,6 +156,8 @@ func overrideDefaultsFromConfig() error {
 			f.Value.Set(config.Ollama.Address)
 		case "ollama-model":
 			f.Value.Set(config.Ollama.Model)
+		case "ollama-content-length-override":
+			f.Value.Set(strconv.Itoa(config.Ollama.ContextLengthOverride))
 		case "ollama-update-model":
 			f.Value.Set(strconv.FormatBool(config.Ollama.UpdateModel))
 		case "openai-enabled":

--- a/pkg/summarize/summarize.go
+++ b/pkg/summarize/summarize.go
@@ -1,6 +1,36 @@
 package summarize
 
-import _ "embed"
+import (
+	_ "embed"
+
+	"github.com/pkoukk/tiktoken-go"
+	tokenLoader "github.com/pkoukk/tiktoken-go-loader"
+	"github.com/sashabaranov/go-openai"
+)
+
+func init() {
+	tiktoken.SetBpeLoader(tokenLoader.NewOfflineLoader())
+}
 
 //go:embed summary_system_prompt.txt
 var summarySystemPrompt string
+
+// NumTokensFromMessages gives a rough token count estimate.
+func NumTokensFromMessages(messages []openai.ChatCompletionMessage) (numTokens int) {
+	tkm, _ := tiktoken.GetEncoding("cl100k_base")
+
+	tokensPerMessage := 3
+	tokensPerName := 1
+
+	for _, message := range messages {
+		numTokens += tokensPerMessage
+		numTokens += len(tkm.Encode(message.Content, nil, nil))
+		numTokens += len(tkm.Encode(message.Role, nil, nil))
+		numTokens += len(tkm.Encode(message.Name, nil, nil))
+		if message.Name != "" {
+			numTokens += tokensPerName
+		}
+	}
+	numTokens += 3 // every reply is primed with <|start|>assistant<|message|>
+	return numTokens
+}


### PR DESCRIPTION
Currently token counting will only result in warnings except for `llama3-gradient` where the token window will be adjusted on the fly.

Also moved the main.go into the correct `cmd/` folder.